### PR TITLE
Fix circular dependency

### DIFF
--- a/deblack/__init__.py
+++ b/deblack/__init__.py
@@ -1,1 +1,1 @@
-from deblack import main
+


### PR DESCRIPTION
Currently, when trying to use deblack, I get the following output:

```
Traceback (most recent call last):
  File "/bin/deblack", line 5 in <module>
    frofm deblack.deblack import main
  File "/python3.10/site-packages/deblack/__init__.py", line 1, in <module>
ImportError: cannot import name 'main' from partially initialized module 'deblack' (most likely due to a circular import) (lib/site-packages/deblack/__init__.py)
```

This change fixes that.