### PR TITLE
Properly handle black at end + use all trims + remove shlex

### DIFF
--- a/deblack/deblack.py
+++ b/deblack/deblack.py
@@ -54,6 +54,13 @@ def get_blackdetect(inpath, invert=False):
     times = [float(x.split("=")[1].strip()) for x in delete_back2back(lines) if x]
     assert len(times), "no black detected"
 
+    # Handle video ending with black by adding "duration" as last trim if needed
+    if len(times) % 2 != 0:
+        video_length_cmd = ["ffprobe", "-i", inpath, "-show_entries", "format=duration", "-of", "csv=p=0", "-v", "quiet"]
+        video_length_str = subprocess.check_output(video_length_cmd).decode("utf-8")
+        video_length = float(video_length_str)
+        times.append(video_length)
+
     if not invert:
         times = [0] + times[:-1]
     timepairs = [(times[i], times[i + 1]) for i in range(0, len(times) // 2, 2)]

--- a/deblack/deblack.py
+++ b/deblack/deblack.py
@@ -10,7 +10,6 @@ Use ffprobe to extract black frames and ffmpeg to trim them and output a new vid
 
 import argparse
 import os
-import shlex
 import subprocess
 
 
@@ -21,32 +20,36 @@ def delete_back2back(l):
 
 
 def construct_ffmpeg_trim_cmd(timepairs, inpath, outpath, has_audio=True):
-    cmd = f'ffmpeg -i "{inpath}" -y -filter_complex '
-    cmd += '"'
+    cmd = ["ffmpeg", "-i", inpath, "-y", "-filter_complex"]
+
+    filter_str = ""
     for i, (start, end) in enumerate(timepairs):
-        cmd += (
+        filter_str += (
             f"[0:v]trim=start={start}:end={end},setpts=PTS-STARTPTS,format=yuv420p[{i}v]; "
             + (f"[0:a]atrim=start={start}:end={end},asetpts=PTS-STARTPTS[{i}a]; " if has_audio else "")
         )
     for i, (start, end) in enumerate(timepairs):
-        cmd += f"[{i}v]"
+        filter_str += f"[{i}v]"
         if has_audio:
-            cmd += f"[{i}a]"
+            filter_str += f"[{i}a]"
 
     audio_cmd = " [outa]" if has_audio else ""
     audio_cmd1 = ":a=1" if has_audio else ""
-    cmd += f"concat=n={len(timepairs)}:v=1{audio_cmd1}[outv]{audio_cmd}"
-    cmd += '"'
-    audio_cmd = " -map [outa]" if has_audio else ""
-    cmd += f' -map [outv]{audio_cmd} "{outpath}"'
+    filter_str += f"concat=n={len(timepairs)}:v=1{audio_cmd1}[outv]{audio_cmd}"
+    cmd.append(filter_str)
+
+    cmd.extend(["-map", "[outv]"])
+    cmd.extend(["-map", "[outa]"] if has_audio else [])
+    cmd.append(outpath)
+
     return cmd
 
 
 def get_blackdetect(inpath, invert=False):
-    ffprobe_cmd = f'ffprobe -f lavfi -i "movie={inpath},blackdetect[out0]" -show_entries tags=lavfi.black_start,lavfi.black_end -of default=nw=1 -v quiet'
-    print("ffprobe_cmd:", ffprobe_cmd)
+    ffprobe_cmd = ["ffprobe", "-f", "lavfi", "-i", f"movie={inpath},blackdetect[out0]", "-show_entries", "tags=lavfi.black_start,lavfi.black_end", "-of", "default=nw=1", "-v", "quiet"]
+    print("ffprobe_cmd:", " ".join(ffprobe_cmd))
     lines = (
-        subprocess.check_output(shlex.split(ffprobe_cmd)).decode("utf-8").split("\n")
+        subprocess.check_output(ffprobe_cmd).decode("utf-8").split("\n")
     )
     times = [float(x.split("=")[1].strip()) for x in delete_back2back(lines) if x]
     assert len(times), "no black detected"
@@ -92,7 +95,8 @@ def main():
 
     if args.audio == "auto":
         try:
-            args.audio = subprocess.check_output(shlex.split(f'ffprobe -i "{args.input}" -show_streams -select_streams a -loglevel error')).decode("utf-8").strip() != ""
+            cmd = ["ffprobe", "-i", args.input, "-show_streams", "-select_streams", "a", "-loglevel", "error"]
+            args.audio = subprocess.check_output(cmd).decode("utf-8").strip() != ""
         except Exception as e:
             print(e, "Failed to detect audio, assuming no audio. Use --audio to override.")
     else:
@@ -103,7 +107,7 @@ def main():
 
     print(cmd)
     # run the command cmd
-    subprocess.call(shlex.split(cmd))
+    subprocess.call(cmd)
 
 if __name__ == "__main__":
     main()

--- a/deblack/deblack.py
+++ b/deblack/deblack.py
@@ -63,7 +63,8 @@ def get_blackdetect(inpath, invert=False):
 
     if not invert:
         times = [0] + times[:-1]
-    timepairs = [(times[i], times[i + 1]) for i in range(0, len(times) // 2, 2)]
+
+    timepairs = [(times[i], times[i + 1]) for i in range(0, len(times), 2)]
     return timepairs
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="deblack",
-    version="0.0.1",
+    version="0.0.2",
     description="Script to remove black frames from a video",
     long_description=long_description,
     url="https://github.com/FarisHijazi/deblack",


### PR DESCRIPTION
This combines a lot of changes in one. I can break them out if need be.

1. Removes `shlex` as a dependency. shlex doesn't work on Windows, plus I see no reason to use it when subprocess should handle escaping when used with arrays
1. Fixes issue where half of trims were being discarded, leading to truncated videos
1. Fixes issue where trims at end weren't being applied due to ffprobe's output not outputting the corresponding "end" tag 